### PR TITLE
Latest updates from rbenv-update upstream

### DIFF
--- a/bin/nodenv-sh-update
+++ b/bin/nodenv-sh-update
@@ -2,7 +2,35 @@
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
-echo "$(which nodenv-update)"
-echo 'echo -e "\033[1;32mreloading nodenv\033[0m"'
-eval "$(nodenv init -)"
-echo 'echo -e " \033[1;32m|\033[0m  done"'
+shell="$(basename "${NODENV_SHELL:-$SHELL}")"
+
+case "$shell" in
+fish )
+  cat <<EOF
+command nodenv update $@
+if command test -t 1
+  printf "\\e[1;32mreloading nodenv\\e[0m\\n"
+  . (nodenv init -|psub)
+  printf " \\033[1;32m|\\033[0m  done\\n"
+else
+  printf "reloading nodenv\\n"
+  . (nodenv init -|psub)
+  printf " |  done\\n"
+end
+EOF
+  ;;
+* )
+  cat <<EOF
+command nodenv update $@;
+if [ -t 1 ]; then
+  printf "\\e[1;32mreloading nodenv\\e[0m\\n";
+  eval "\$(nodenv init -)";
+  printf " \\033[1;32m|\\033[0m  done\\n";
+else
+  printf "reloading nodenv\\n";
+  eval "\$(nodenv init -)";
+  printf " |  done\\n";
+fi
+EOF
+  ;;
+esac

--- a/bin/nodenv-update
+++ b/bin/nodenv-update
@@ -1,23 +1,47 @@
 #!/usr/bin/env bash
+# Usage: nodenv update [--noop]
+# Summary: Updates to latest version of nodenv and plugins from git.
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
+noop=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --noop ) noop=true ;;
+  esac
+  shift 1
+done
+
+git() {
+  local cmd="command"
+  [[ -n "$noop" && "$1" = "pull" ]] && cmd="echo"
+  $cmd git "$@"
+}
+
+if [ -t 1 ]; then
+  color="\e[1;32m"
+  reset="\e[0m"
+else
+  color=""
+  reset=""
+fi
+
 indent_output() {
   while read data; do
-    echo -e " \033[1;32m|\033[0m  $data"
+    printf " ${color}|${reset}  %s\n" "$data"
   done
 }
 
 is_nodenv_git_repo() {
-  $(git remote -v | grep -E 'nodenv|node-build' &>/dev/null)
+  git remote -v 2>/dev/null | grep -q 'nodenv\|node-build'
 }
 
 nodenv_update() {
-  echo -e "\033[1;32mupdating $1\033[0m"
+  printf "${color}updating %s${reset}\n" "$1"
   if is_nodenv_git_repo; then
     git pull --no-rebase --ff 2>&1 | indent_output
   else
-    echo -e "Not a nodenv git repo; skipping..." | indent_output
+    echo "Not an nodenv git repo; skipping..." | indent_output
   fi
   echo
 }
@@ -25,9 +49,10 @@ nodenv_update() {
 cd "$(dirname $(which nodenv))"
 nodenv_update nodenv
 
-cd "${NODENV_ROOT:-$(nodenv root)}"
-for plugin in plugins/*; do
+shopt -s nullglob
+for plugin in "$NODENV_ROOT"/plugins/*; do
   pushd $plugin >/dev/null
   nodenv_update `basename $plugin`
   popd >/dev/null
 done
+shopt -u nullglob


### PR DESCRIPTION
- Add support for fish shell
- Fix invoking `nodenv update` from nodenv-sh-update
- Fix invoking `nodenv update` from nodenv-sh-update
- Simplify "is_nodenv_git_repo" check
- Only output color if stdout is to a terminal
- Add `--noop` argument to show what would be done
- `sh-update` output should only be colored if stdout is a tty
- Handle the situation where there might be no nodenv plugins
- Avoid fish's broken `test` builtin
- Compensate for old nodenv sh-* comments eval bug